### PR TITLE
Use context managers for tempfiles and zipping

### DIFF
--- a/pretix_espass/espass.py
+++ b/pretix_espass/espass.py
@@ -1,17 +1,15 @@
 import tempfile
 from collections import OrderedDict
+from zipfile import ZipFile
+
 from typing import Tuple
 import os
-import shutil
 import json
-from shutil import make_archive
 from django import forms
 from django.utils.translation import ugettext, ugettext_lazy as _
 from django.core.files.storage import default_storage
 from pretix.base.models import Order
 from pretix.base.ticketoutput import BaseTicketOutput
-from pretix.multidomain.urlreverse import build_absolute_uri
-from wallet.models import Barcode, BarcodeFormat, EventTicket, Location, Pass
 
 from .forms import PNGImageField
 
@@ -58,9 +56,6 @@ class EspassOutput(BaseTicketOutput):
 
     def generate(self, order_position: Order) -> Tuple[str, str, str]:
         order = order_position.order
-
-        temp_in = tempfile.mkdtemp()
-        temp_out = tempfile.mkdtemp()
 
         ticket = str(order_position.item)
         if order_position.variation:
@@ -120,31 +115,17 @@ class EspassOutput(BaseTicketOutput):
                 "lon": self.event.settings.ticketoutput_espass_longitude
             })
 
-        icon_file = self.event.settings.get('ticketoutput_espass_icon')
-        read = default_storage.open(icon_file.name, 'rb').read()
-        open(os.path.join(temp_in, 'icon.png'), 'wb').write(read)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with ZipFile(os.path.join(tmp_dir, 'tmp.zip'), 'w') as zipf:
 
-        icon_file = self.event.settings.get('ticketoutput_espass_logo')
-        read = default_storage.open(icon_file.name, 'rb').read()
-        open(os.path.join(temp_in, 'logo.png'), 'wb').write(read)
+                icon_file = self.event.settings.get('ticketoutput_espass_icon')
+                zipf.writestr('icon.png', default_storage.open(icon_file.name, 'rb').read())
 
-        with open(os.path.join(temp_in, 'main.json'), 'w') as outfile:
-            json.dump(data, outfile, indent=4, separators=(',', ':'))
+                logo_file = self.event.settings.get('ticketoutput_espass_logo')
+                zipf.writestr('logo.png', default_storage.open(logo_file.name, 'rb').read())
 
-        zip_file = make_archive(
-            os.path.join(temp_out, 'zipfile_name'),
-            'zip',
-            root_dir=temp_in,
-        )
+                zipf.writestr('main.json', json.dumps(data, indent=4, separators=(',', ':')))
 
-        filename = 'foo_{}-{}.espass'.format(order.event.slug, order.code)
-
-        zip_content = open(zip_file, "rb").read()
-        self.cleanup(temp_in, temp_out)
-
-        return filename, 'application/vnd.espass-espass+zip', zip_content
-
-    @staticmethod
-    def cleanup(temp_in, temp_out):
-        shutil.rmtree(temp_in)
-        shutil.rmtree(temp_out)
+            with open(os.path.join(tmp_dir, 'tmp.zip'), 'rb') as zipf:
+                filename = 'foo_{}-{}.espass'.format(order.event.slug, order.code)
+                return filename, 'application/vnd.espass-espass+zip', zipf.read()


### PR DESCRIPTION
This is not only cleaner (and shorter), it mainly is better because it will make sure temporary files will be cleaned up even if an exception occurs along the way.