### PR TITLE
compatibility with django>3 - ugettext removal

### DIFF
--- a/pretix_espass/__init__.py
+++ b/pretix_espass/__init__.py
@@ -1,6 +1,5 @@
 from django.apps import AppConfig
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
 from pretix.base.plugins import PluginType
 
 
@@ -11,7 +10,7 @@ class EspassApp(AppConfig):
     class PretixPluginMeta:
         type = PluginType.ADMINFEATURE
         name = "esPass Tickets"
-        author = _("ligi")
+        author = "ligi"
         version = '1.0.0'
         description = "Provides esPass ticket download support"
         visible = True

--- a/pretix_espass/__init__.py
+++ b/pretix_espass/__init__.py
@@ -11,7 +11,7 @@ class EspassApp(AppConfig):
         type = PluginType.ADMINFEATURE
         name = "esPass Tickets"
         author = "ligi"
-        version = '1.0.0'
+        version = '1.1.0'
         description = "Provides esPass ticket download support"
         visible = True
 

--- a/pretix_espass/espass.py
+++ b/pretix_espass/espass.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile
 import pytz
 from django import forms
 from django.core.files.storage import default_storage
-from django.utils.translation import ugettext, ugettext_lazy as _  # NOQA
+from django.utils.translation import gettext, gettext_lazy as _  # NOQA
 from pretix.base.models import Order
 from pretix.base.ticketoutput import BaseTicketOutput
 from pretix.multidomain.urlreverse import build_absolute_uri
@@ -85,32 +85,32 @@ class EspassOutput(BaseTicketOutput):
                 'fields': [
                     {
                         "hide": False,
-                        "label": ugettext('Product'),
+                        "label": gettext('Product'),
                         "value": ticket
                     },
                     {
                         "hide": True,
-                        "label": ugettext('Ordered by'),
+                        "label": gettext('Ordered by'),
                         "value": order.email
                     },
                     {
                         "hide": True,
-                        "label": ugettext('Order code'),
+                        "label": gettext('Order code'),
                         "value": order.code
                     },
                     {
                         "hide": True,
-                        "label": ugettext('Organizer'),
+                        "label": gettext('Organizer'),
                         "value": str(order.event.organizer)
                     },
                     {
                         "hide": False,
-                        "label": ugettext('From'),
+                        "label": gettext('From'),
                         "value": order.event.get_date_from_display(tz)
                     },
                     {
                         "hide": True,
-                        "label": ugettext('Website'),
+                        "label": gettext('Website'),
                         "value": build_absolute_uri(order.event, 'presale:event.index')
                     },
                 ]
@@ -119,7 +119,7 @@ class EspassOutput(BaseTicketOutput):
         if order.event.date_to:
             data["calendarTimespan"]["to"] = order.event.date_to.isoformat()
             data["fields"].append({
-                "label": ugettext('To'),
+                "label": gettext('To'),
                 "value": order.event.get_date_to_display(tz),
                 "hide": False
             })
@@ -128,39 +128,39 @@ class EspassOutput(BaseTicketOutput):
             if order_position.seat:
                 if order_position.seat.zone_name:
                     data["fields"].append({
-                        "label": ugettext('Zone'),
+                        "label": gettext('Zone'),
                         "value": order_position.seat.zone_name,
                         "hide": False
                     })
                 if order_position.seat.row_name:
                     data["fields"].append({
-                        "label": ugettext('Row'),
+                        "label": gettext('Row'),
                         "value": order_position.seat.row_name,
                         "hide": False
                     })
                 if order_position.seat.seat_number:
                     data["fields"].append({
-                        "label": ugettext('Seat'),
+                        "label": gettext('Seat'),
                         "value": order_position.seat.seat_number,
                         "hide": False
                     })
             else:
                 data["fields"].append({
-                    "label": ugettext('Seat'),
-                    "value": ugettext('General admission'),
+                    "label": gettext('Seat'),
+                    "value": gettext('General admission'),
                     "hide": False
                 })
 
         if order_position.attendee_name:
             data["fields"].append({
-                "label": ugettext('Attendee name'),
+                "label": gettext('Attendee name'),
                 "value": order_position.attendee_name,
                 "hide": False
             })
 
         if order.event.settings.contact_mail:
             data["fields"].append({
-                "label": ugettext('Organizer contact'),
+                "label": gettext('Organizer contact'),
                 "value": order.event.settings.contact_mail,
                 "hide": False
             })

--- a/pretix_espass/forms.py
+++ b/pretix_espass/forms.py
@@ -5,7 +5,7 @@ import tempfile
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile, UploadedFile
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from pretix.control.forms import ClearableBasenameFileInput
 
 logger = logging.getLogger(__name__)

--- a/pretix_espass/signals.py
+++ b/pretix_espass/signals.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 
 from django import forms
 from django.dispatch import receiver
-from django.utils.translation import ugettext_lazy as _
 from pretix.base.signals import (
     register_global_settings, register_ticket_outputs,
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pretix-espass',
-    version='0.0.0',
+    version='1.1.0',
     description='esPass support for pretix',
     long_description='Provides support for the esPass ticket format',
     url='https://github.com/espass/pretix-espass',


### PR DESCRIPTION
both `ugettext_lazy` and `ugettext` are deprecated in Django, long time they were just aliases for `gettext_lazy` and `gettext`. The same way similar functions were unified in python3.

https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0
https://docs.djangoproject.com/en/3.2/topics/i18n/translation/#lazy-translations

Bumping version se we can make a release straight away.